### PR TITLE
feat(model): crear entidades Question y QuizResult

### DIFF
--- a/backend/src/main/java/com/example/quizzutp/model/Question.java
+++ b/backend/src/main/java/com/example/quizzutp/model/Question.java
@@ -1,0 +1,37 @@
+package com.example.quizzutp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "questions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Question {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, length = 500)
+    private String questionText;
+    
+    @Column(nullable = false)
+    private String option1;
+    
+    @Column(nullable = false)
+    private String option2;
+    
+    @Column(nullable = false)
+    private String option3;
+    
+    @Column(nullable = false)
+    private String option4;
+    
+    @Column(nullable = false)
+    private Integer correctAnswer; // 1, 2, 3, o 4
+    
+    private String difficulty; // "facil", "medio", "dificil"
+}

--- a/backend/src/main/java/com/example/quizzutp/model/QuizResult.java
+++ b/backend/src/main/java/com/example/quizzutp/model/QuizResult.java
@@ -1,0 +1,37 @@
+package com.example.quizzutp.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "quiz_results")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private Usuarios usuario;
+    
+    @Column(nullable = false)
+    private Integer score;
+    
+    @Column(nullable = false)
+    private Integer totalQuestions;
+    
+    @Column(nullable = false)
+    private LocalDateTime completedAt;
+    
+    @Column(nullable = false)
+    private Integer correctAnswers;
+    
+    @Column(nullable = false)
+    private Integer incorrectAnswers;
+}


### PR DESCRIPTION
- Question: agregar campos para pregunta, 4 opciones, respuesta correcta y dificultad
- Configurar tabla 'questions' con anotaciones JPA
- QuizResult: crear entidad para almacenar resultados de quiz